### PR TITLE
Add option to set transparent background for printed PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ puppeteer-pdf --help
     -mr, --marginRight [margin]       Right margin, accepts values labeled with units.
     -mb, --marginBottom [margin]      Bottom margin, accepts values labeled with units.
     -ml, --marginLeft [margin]        Left margin, accepts values labeled with units.
+    -stb, --setTransparentBackground  Sets transparent background in resulting PDF. Uses the workaround described here: https://github.com/GoogleChrome/puppeteer/issues/2545#issuecomment-397590569
     -d, --debug                       Output Puppeteer PDF options
     -wu, --waitUntil [choice]         waitUntil accepts choices load, domcontentloaded, networkidle0, networkidle2. Defaults to 'networkidle2'. (default: networkidle2)
     -h, --help                        output usage information

--- a/puppeteer-pdf.js
+++ b/puppeteer-pdf.js
@@ -66,6 +66,7 @@ cli
     "waitUntil accepts choices load, domcontentloaded, networkidle0, networkidle2. Defaults to 'networkidle2'.",
     "networkidle2"
   )
+  .option("-stb, --setTransparentBackground", "Set transparent background.", false)
   .action(function(required, optional) {
     // TODO: Implement required arguments validation
   })
@@ -115,6 +116,14 @@ cli
   if (cli.debug) {
     console.log(options);
   }
+  
+  if (cli.setTransparentBackground) {
+    await page._emulationManager._client.send(
+      'Emulation.setDefaultBackgroundColorOverride',
+      { color: { r: 0, g: 0, b: 0, a: 0 } }
+    );
+  }
+
   await page.pdf(options);
 
   await browser.close();


### PR DESCRIPTION
Hi!

This PR adds the possibility to set a transparent background for the resulting PDF. It uses a method described here: https://github.com/GoogleChrome/puppeteer/issues/2545#issuecomment-397590569

It can be set by passing a flag called `--setTransparentBackground` as one of the command line arguments. 

This change is useful when you need to generate a PDF which will be later used as watermark for some other PDF document. Otherwise, if the file doesn't have a transparent background, it cannot be used for such a case.

**Note:** The short version of this flag (`-stb`) doesn't work, just as some other flags don't work. There is already an issue opened here https://github.com/namespace-ee/puppeteer-pdf/issues/7. I was not able to figure out why those flags don't work. 